### PR TITLE
Line ending quick fix for maven-wrapper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+mvnw eol=lf


### PR DESCRIPTION
I faced some line ending issues with `mvnw` on my Mac. The file is currently checked-in with `CRLF`. I think this could be helpful for others as well. 